### PR TITLE
Add array merge of "pdo_options" key from the connection config to allow

### DIFF
--- a/src/Database/Connectors/Connector.php
+++ b/src/Database/Connectors/Connector.php
@@ -6,38 +6,43 @@ use PDO;
 
 abstract class Connector
 {
+
     /**
-    * The default PDO connection options.
-    *
-    * @var array
-    */
-   protected $options = [
-       PDO::ATTR_CASE => PDO::CASE_NATURAL,
-       PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-       PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
-       PDO::ATTR_STRINGIFY_FETCHES => false,
-       PDO::ATTR_EMULATE_PREPARES => true,
-       PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-   ];
+     * The default PDO connection options.
+     *
+     * @var array
+     */
+    protected $options = [
+        PDO::ATTR_CASE               => PDO::CASE_NATURAL,
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_ORACLE_NULLS       => PDO::NULL_NATURAL,
+        PDO::ATTR_STRINGIFY_FETCHES  => false,
+        PDO::ATTR_EMULATE_PREPARES   => true,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ];
 
-   /**
-   * Connect to a database.
-   *
-   * @param array $config
-   * @return \PDO
-   */
-   abstract public function connect($config);
+    /**
+     * Connect to a database.
+     *
+     * @param array $config
+     * @return \PDO
+     */
+    abstract public function connect($config);
 
-   /**
+    /**
      * Create a new PDO connection.
      *
      * @param string $dsn
      * @param array $config
-     * @param array $options
      * @return \PDO
      */
     public function createConnection($dsn, array $config)
     {
+        // Merge custom PDO options from the connection config if available
+        if (array_key_exists('pdo_options', $config) && is_array($config['pdo_options'])) {
+            $this->options = array_merge($this->options, $config['pdo_options']);
+        }
+
         $username = isset($config['username']) ? $config['username'] : null;
 
         $password = isset($config['password']) ? $config['password'] : null;
@@ -45,6 +50,4 @@ abstract class Connector
         return new PDO($dsn, $username, $password, $this->options);
     }
 
-
-   // TODO: method to merge custom options
 }

--- a/src/Database/Connectors/MySqlConnector.php
+++ b/src/Database/Connectors/MySqlConnector.php
@@ -2,8 +2,6 @@
 
 namespace Marquine\Etl\Database\Connectors;
 
-use PDO;
-
 class MySqlConnector extends Connector
 {
     /**


### PR DESCRIPTION
Add array merge of "pdo_options" key from the connection config to allow custom PDO options.

Reformat Connector class to use PSR-2 guidelines.
Remove unused PDO use statement.