### PR TITLE
Added connector to support MsSql.

### DIFF
--- a/src/Database/ConnectionFactory.php
+++ b/src/Database/ConnectionFactory.php
@@ -38,6 +38,8 @@ class ConnectionFactory
                 return new Connectors\MySqlConnector;
             case 'pgsql':
                 return new Connectors\PostgresConnector;
+            case 'mssql':
+                return new Connectors\MsSqlConnector;
         }
 
         throw new InvalidArgumentException("Unsupported driver: $driver");

--- a/src/Database/Connectors/MsSqlConnector.php
+++ b/src/Database/Connectors/MsSqlConnector.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Marquine\Etl\Database\Connectors;
+
+class MsSqlConnector extends Connector
+{
+    /**
+    * Connect to a database.
+    *
+    * @param  array  $config
+    * @return \PDO
+    */
+    public function connect($config)
+    {
+        $dsn = $this->getDsn($config);
+
+        $connection = $this->createConnection($dsn, $config);
+
+        $this->afterConnection($connection, $config);
+
+        return $connection;
+    }
+
+    /**
+     * Get the DSN string.
+     *
+     * @param  array  $config
+     * @return string
+     */
+    public function getDsn($config)
+    {
+        extract($config, EXTR_SKIP);
+
+        $dsn = [];
+
+        if (isset($host) && ! isset($unix_socket)) {
+            $dsn['host'] = $host;
+        }
+
+        if (isset($port) && ! isset($unix_socket)) {
+            $dsn['port'] = $port;
+        }
+
+        if (isset($database)) {
+            $dsn['dbname'] = $database;
+        }
+
+        return 'dblib:' . http_build_query($dsn, '', ';');
+    }
+
+    /**
+     * Handle tasks after connection.
+     *
+     * @param  \PDO  $connection
+     * @param  array  $config
+     * @return void
+     */
+    public function afterConnection($connection, $config)
+    {
+        extract($config, EXTR_SKIP);
+
+        if (isset($database)) {
+            $connection->exec("USE $database");
+        }
+
+    }
+}


### PR DESCRIPTION
From PHP Manual site:

Disclaimer: this is how I was able to connect to a Microsoft sql server via PDO using the PECL pdo_sqlsrv extension and unixodbc. PHP 7.2. Linux – Slackware 14.2. These comments represent my understanding at the time I wrote this, what I did to get this working, and may contain errors. I am not responsible for any problems or damage etc. that might occur if you follow these instructions. YMMV. This worked for me, I hope it helps you.

This is an extension to the comment I posted yesterday that can be found here (http://php.net/manual/en/ref.pdo-sqlsrv.connection.php). This version is more complete and includes expanded instructions.

I compiled and installed PHP from source. If you use your package manager to do this, then it is up to you to figure out how to get --with-pdo-dblib --with-pdo-odbc=unixODBC working, as well as how to install the PECL pdo_sqlsrv extension.

Do NOT install freetds. pdo_sqlsrv does not require freetds.
Do NOT install the Microsoft ODBC driver. pdo_sqlsrv does not use it.
Do NOT install the PECL "sqlsrv" extension. It is not needed.

Install unixODBC. I had to download and install from source because the package manager version did not work. How you do this is up to you, but if you get compile errors when compiling PHP, your unixODBC install is a likely culprit.

Install PHP 7.2 (or whatever version you want). When you configure PHP, be sure to include:

`  --with-pdo-dblib --with-pdo-odbc=unixODBC`

If you get compile errors, try it without --with-pdo-odbc=unixODBC to make sure it isn't something else causing the problem.

After you get PHP installed and working, install the PECL pdo_sqlsrv extension:

`pecl install pdo_sqlsrv`

This is all the setup that is required to get this to work.

This is how I successfully connected to and queried a mssql table. In this case, I used the ip address of my sql server, not host or server name. Notice the variable names $pdo_object and $pdo_statement_object. I used them to indicate what data types those variables actually represent. $dsn is simply a text string containing the ip address and default database for the connection to your mssql server. Also note that in $dsn we use “dblib:host”, NOT “sqlsrv:host”. I believe this to be a critical distinction, as many examples of how to use pdo seem to use “sqlsrv:host”, which IIAC utilizes the sqlsrv extension and the MS ODBC driver, *not* pdo. This caused me a lot of grief until I figured this out.

```
<?php

$dsn = 'dblib:host=<ip address>;dbname=<database name>';
$user = 'user id';
$password = 'password';

try
{
    $pdo_object = new PDO($dsn, $user, $password);
}
catch (PDOException $e)
{
    echo 'Connection failed: ' . $e->getMessage();
}

$sql = "SELECT * from <some table>";
$pdo_statement_object = $pdo_object->prepare($sql);
$pdo_statement_object->execute();
// $result = $pdo_statement_object->fetch(PDO::FETCH_ASSOC);
$result = $pdo_statement_object->fetchAll();
print_r($result);
?>
```