### PR TITLE
Fix wrong docblock type in the Csv:makeColumns method

### DIFF
--- a/src/Extractors/Csv.php
+++ b/src/Extractors/Csv.php
@@ -77,7 +77,7 @@ class Csv extends Extractor
     /**
      * Make columns based on csv header.
      *
-     * @param  array  $handle
+     * @param  resource $handle
      * @return array
      */
     protected function makeColumns($handle)


### PR DESCRIPTION
Fixed the docblock type for the method _makeColums_ in the extractor _Csv_. This was triggering an error - in any "clean" override - with PHPStan at level > 4.