### PR TITLE
Support the latest illuminate/container package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "flow/jsonpath": "^0.3.1",
-        "illuminate/container": "^5.0|^6.0"
+        "illuminate/container": "^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
*What*
Enable Laravel 7.x support.

*How*
Allow the latest `illuminate/container` to be used in the composer.json file

*Description*

Literally no idea if this is going to cause errors within this package, and if it does I will be happy to fix them of course.