### PR TITLE
Update Csv.php

### DIFF
--- a/src/Extractors/Csv.php
+++ b/src/Extractors/Csv.php
@@ -68,7 +68,7 @@ class Csv extends Extractor
         $data = [];
 
         foreach ($columns as $column => $index) {
-            $data[$column] = $row[$index - 1];
+            $data[$column] = $row[$index - 1] != "" ? $row[$index - 1] : NULL ;
         }
 
         return $data;


### PR DESCRIPTION
If the CSV field is empty it can cause an SQL error, replacing it with NULL does not cause an error.

Note: Database column cannot be "NOT NULL"